### PR TITLE
REPO-4569: Use registryPullSecrets as a global value so it can get override from a parent Alfresco Helm chart(s)

### DIFF
--- a/helm/alfresco-sync-service/Chart.yaml
+++ b/helm/alfresco-sync-service/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-sync-service
-version: 2.0.0-RC1
+version: 2.0.0-RC2
 appVersion: 3.2.0
 description: Alfresco Syncservice
 keywords:

--- a/helm/alfresco-sync-service/templates/deployment-syncservice.yaml
+++ b/helm/alfresco-sync-service/templates/deployment-syncservice.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/config-syncservice.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecret }}
       initContainers:
       {{- if eq .Values.activemq.external false }}
       - name: init-activemq

--- a/helm/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-sync-service/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
-registryPullSecrets: quay-registry-secret
+
+# Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s)
+global:
+  alfrescoRegistryPullSecret: quay-registry-secret
 
 syncservice:
   image:


### PR DESCRIPTION
- Use a global variable for registryPullSecrets and rename is to Alfresco org related
- Bump chart version to `2.0.0-RC2`
