### PR TITLE
REPO-4569: Use registryPullSecrets as a global value so it can get override from a parent Alfresco Helm chart(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 target
 
 *.tar.gz
+
+helm/alfresco-sync-service/charts
+helm/alfresco-sync-service/requirements.lock
+helm/alfresco-sync-service*.tgz

--- a/helm/alfresco-sync-service/Chart.yaml
+++ b/helm/alfresco-sync-service/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-sync-service
-version: 1.1.0
+version: 1.1.1
 appVersion: 3.1.2
 description: Alfresco Syncservice
 keywords:

--- a/helm/alfresco-sync-service/templates/deployment-syncservice.yaml
+++ b/helm/alfresco-sync-service/templates/deployment-syncservice.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/config-syncservice.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecret }}
       initContainers:
       {{- if eq .Values.activemq.external false }}
       - name: init-activemq

--- a/helm/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-sync-service/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
-registryPullSecrets: quay-registry-secret
+
+# Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s)
+global:
+  alfrescoRegistryPullSecret: quay-registry-secret
 
 syncservice:
   image:


### PR DESCRIPTION
- Changes for branch `support/SP/1.N` to support ACS 6.1.x
- Use registryPullSecrets as a global variable so it can be passed via parent ACS Helm chart(s)
- Append `.gitignore` file for un-needed files
- Bump the Chart version to `1.1.1`