### PR TITLE
MNT-21042: ACS Helm upgrade fails to perform rolling update with zero downtime

### DIFF
--- a/helm/alfresco-sync-service/templates/deployment-syncservice.yaml
+++ b/helm/alfresco-sync-service/templates/deployment-syncservice.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+{{ toYaml .Values.global.strategy.rollingUpdate | indent 6 }}
   template:
     metadata:
       labels:
@@ -16,6 +20,7 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config-syncservice.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-database.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
         - name: {{ .Values.global.alfrescoRegistryPullSecrets }}

--- a/helm/alfresco-sync-service/values.yaml
+++ b/helm/alfresco-sync-service/values.yaml
@@ -3,6 +3,10 @@ replicaCount: 1
 # Global definition of Docker registry pull secret which can be overridden from parent ACS Helm chart(s)
 global:
   alfrescoRegistryPullSecrets: quay-registry-secret
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 
 syncservice:
   image:


### PR DESCRIPTION
- Make `rollingUpgrade` parameters as `global` values so it can inherit from it's parent helm chart (ex: ACS helm chart)
- Trigger a pod update when [secret-database](https://github.com/Alfresco/alfresco-dsync-services-deployment/blob/master/helm/alfresco-sync-service/templates/secret-database.yaml) is changed